### PR TITLE
Fixes

### DIFF
--- a/globals.gd
+++ b/globals.gd
@@ -1371,7 +1371,7 @@ var sexuality_images = {
 	futa_3 = load("res://files/aric_expansion_images/sexuality_icons/futa_3.png"),
 }
 
-<AddTo -1>
+<AddTo 0>
 func _ready():
 	if useRalphsTweaks:
 		expansionsettings.applyTweaks()

--- a/scripts/mainmenu.gd
+++ b/scripts/mainmenu.gd
@@ -385,7 +385,7 @@ func _on_slaveconfirm_pressed():
 
 	#Generate mental stats
 	for i in ['conf','cour','wit','charm']:
-		startSlave[i] = rand_range(30,35)
+		startSlave.stats[i+'_base'] = rand_range(30,35)
 	startSlave.obed = 90
 	startSlave.beautybase = variables.characterstartbeauty
 	if startSlave.memory.find('$sibling') >= 0:

--- a/scripts/mainmenu.gd
+++ b/scripts/mainmenu.gd
@@ -461,6 +461,7 @@ func _on_slaveconfirm_pressed():
 	globals.constructor.forceFullblooded(startSlave)
 	globals.constructor.setRaceDisplay(startSlave)
 	globals.constructor.set_ovulation(startSlave)
+	globals.expansionsetup.setRaceBonus(startSlave, true)
 	###---End Expansion---###
 	###---Added by Expansion---### Ank Bugfix v4
 	startSlave.health = 1000

--- a/scripts/person/person.gd
+++ b/scripts/person/person.gd
@@ -534,28 +534,28 @@ func loyal_set(value):
 ###---Added by Expansion---### Modified by Deviate - Allow current stat up to max stat
 func cour_set(value):
 	if stats.cour_max > 100:
-		stats.cour_base = clamp(value, 0, stats.cour_max)
+		stats.cour_base = clamp(value - stats.cour_racial, 0, stats.cour_max)
 	else:
-		stats.cour_base = clamp(value, 0, min(stats.cour_max, originvalue[origins]))
+		stats.cour_base = clamp(value - stats.cour_racial, 0, min(stats.cour_max, originvalue[origins]))
 
 func conf_set(value):
 	var bonus = max(0, stats.conf_max - originvalue['noble'])
 	if stats.conf_max > 100:
-		stats.conf_base = clamp(value, 0, stats.conf_max)
+		stats.conf_base = clamp(value - stats.conf_racial, 0, stats.conf_max)
 	else:
-		stats.conf_base = clamp(value, 0, min(stats.conf_max, originvalue[origins] + bonus))
+		stats.conf_base = clamp(value - stats.conf_racial, 0, min(stats.conf_max, originvalue[origins] + bonus))
 
 func wit_set(value):
 	if stats.wit_max > 100:
-		stats.wit_base = clamp(value, 0, stats.wit_max)
+		stats.wit_base = clamp(value - stats.wit_racial, 0, stats.wit_max)
 	else:
-		stats.wit_base = clamp(value, 0, min(stats.wit_max, originvalue[origins]))
+		stats.wit_base = clamp(value - stats.wit_racial, 0, min(stats.wit_max, originvalue[origins]))
 
 func charm_set(value):
 	if stats.charm_max > 100:
-		stats.charm_base = clamp(value, 0, stats.charm_max)
+		stats.charm_base = clamp(value - stats.charm_racial, 0, stats.charm_max)
 	else:
-		stats.charm_base = clamp(value, 0, min(stats.charm_max, originvalue[origins]))
+		stats.charm_base = clamp(value - stats.charm_racial, 0, min(stats.charm_max, originvalue[origins]))
 ###---End Expansion---###
 
 


### PR DESCRIPTION
The stat setter will assume the racial bonuses are already applied to the value given to it. This is no problem if the getter and setter are used together, but if only setter is used (like in the startslave stats I fixed) it will lead to wrong stats.