### PR TITLE
Flaire's wear and tear improvements

### DIFF
--- a/customScripts/expansionsettings.gd
+++ b/customScripts/expansionsettings.gd
@@ -96,6 +96,7 @@ var vices_discovery_presentation_bonus = 20
 #Disable Tearing System
 var disablevaginatearing = false
 var disableanaltearing = false
+var healthPenaltyWhenTorn = true
 
 #Chance of Holes staying Stretched during Sex. Chance + (Elasticity*10)
 var stretchchancevagina = 50

--- a/scripts/newsexsystem.gd
+++ b/scripts/newsexsystem.gd
@@ -796,7 +796,7 @@ class member:
 					values.sens *= number
 					values.lust *= number
 					if difference > 0 && scenedict.givers.size() <= 1:
-						text += "\n[color=green][name1] {^[is1] enjoying:[is1] loving:[is1] relishing:loves} the feeling of [his1] [penis1] stretching [his2] [pussy2].[/color]"
+						text += "\n[color=green][name1] {^[is1] enjoying:[is1] loving:[is1] relishing:love[s/1]} the feeling of [his1] [penis1] stretching [names2] [pussy2].[/color]"
 					elif difference < 0 && scenedict.givers.size() <= 1:
 						text += "\n[color=red][name1] {^can barely feel:can't feel:can't fill} [names2] [pussy2] with [his1] [penis1].[/color]"
 					#Display
@@ -809,19 +809,38 @@ class member:
 				elif scenedict.takers.has(self) && scenedict.givers.has(i):
 					var temppenissize = globals.penissizearray.find(i.person.penis) if i.person.penis != 'none' else 4 # handle strapon with default size
 					difference = temppenissize - globals.vagsizearray.find(vaginasize)
-					number = 1+(difference*.1)
-					values.sens *= number
-					values.lust *= number
-					if difference > 0:
-						if vagTorn == true:
-							values.sens = values.sens*.75
-							values.lust = values.lust*.75
+					if vagTorn:
+						# If torn, no pleasure boost from a big penetration. It hurts, regardless of size, but some may like it more than others.
+						if person.traits.has('Masochist'):
+							number = 1.2 if person.traits.has('Likes it rough') else 1.1
+							values.sens *= number
+							values.lust *= number
 							if scenedict.takers.size() <= 1:
-								text += "\n[color=red][names2] [pussy2] is {^stretched out:sore:aching:raw:hurting} and [his2] pleasure has lessened.[/color] "
-						elif scenedict.takers.size() <= 1:
-							text += "\n[color=green][names2] {^[is2] enjoying:[is2] loving:[is2] relishing:loves} the feeling of [names1] [penis1] stretching [his2] [pussy2].[/color] "
-					elif difference < 0:
-						text += "\n[color=red][names2] [pussy2] can barely feel [names1] undersized [penis1].[/color] "
+								text += "\n[color=green][names2] [pussy2] [is2] {^stretched out:sore:aching:raw:hurting}, but [he2] {^seems to get off on it:appears to enjoy it:savours the pain}.[/color] "
+						elif person.traits.has('Likes it rough'):
+							values.sens *= .9
+							values.lust *= .9
+							if scenedict.takers.size() <= 1:
+								text += "\n[color=red][names2] [pussy2] [is2] {^stretched out:sore:aching:raw:hurting}, but [he2] {^does [his2] best to take it:gasps and puts up with it:just squeaks and moans a bit}.[/color] "
+						else:
+							values.sens *= .7
+							values.lust *= .7
+							if scenedict.takers.size() <= 1:
+								text += "\n[color=red][names2] [pussy2] [is2] {^stretched out:sore:aching:raw:hurting} and [his2] pleasure {^has lessened:[is2] reduced:[is2] diminished}.[/color] "
+					else:
+						# Not torn. Adjust pleasure and mood text based on size.
+						number = 1 + (difference * .1)
+						values.sens *= number
+						values.lust *= number
+						if scenedict.takers.size() <= 1:
+							if difference > 0:
+								if effects.has('resist') || effects.has('forced'):
+									text += "\n[color=green]Despite [his2] best efforts, [name2] can't help but {^enjoy:be excited by:relish} the feeling of [names1] [penis1] stretching [his2] [pussy2].[/color] "
+								else:
+									text += "\n[color=green][names2] {^[is2] enjoying:[is2] loving:[is2] relishing:loves} the feeling of [names1] [penis1] stretching [his2] [pussy2].[/color] "
+							elif difference < -1:
+								text += "\n[color=red][names2] [pussy2] can barely feel [names1] undersized [penis1].[/color] "
+
 					#Stretching
 					if difference >= 5 + rand_range(-5,0) + person.sexexpanded.pliability:
 						if globals.vagsizearray.back() != vaginasize:
@@ -829,7 +848,7 @@ class member:
 							clamper = clamp(clamper,0,globals.vagsizearray.size()-1)
 							vaginasize = globals.vagsizearray[clamper]
 							if scenedict.takers.size() <= 1:
-								text += "[color=green][name2] {^moans:gasps:spasms:twitches:bites [his2] lip} as [his2] [pussy2] [is2] {^stretched:gaped:spread apart:forced to stretch} by [names1] [penis1].[/color] "
+								text += "\n[color=green][name2] {^moans:gasps:spasms:twitches:bites [his2] lip} as [his2] [pussy2] [is2] {^stretched:gaped:spread apart:forced to stretch} by [names1] [penis1].[/color] "
 							var stretch = globals.vagsizearray.find(vaginasize) - globals.vagsizearray.find(person.vagina)
 							if globals.expansionsettings.disablevaginatearing == false && person.sexexpanded.pliability - stretch + rand_range(0,2) < 0:
 								if vagTorn == false:
@@ -860,7 +879,7 @@ class member:
 					values.sens *= number
 					values.lust *= number
 					if difference > 0 && scenedict.givers.size() <= 1:
-						text += "\n[color=green][name1] {^[is1] enjoying:[is1] loving:[is1] relishing:loves} the feeling of [his1] [penis1] stretching [his2] [anus2].[/color] "
+						text += "\n[color=green][name1] {^[is1] enjoying:[is1] loving:[is1] relishing:love[s/1]} the feeling of [his1] [penis1] stretching [names2] [anus2].[/color] "
 					elif difference < 0 && scenedict.givers.size() <= 1:
 						text += "\n[color=red][name1] {^can barely feel:can't feel:can't fill} [names2] [anus2] with [his1] [penis1].[/color] "
 					#Display
@@ -873,16 +892,38 @@ class member:
 				elif scenedict.takers.has(self) && scenedict.givers.has(i):
 					var temppenissize = globals.penissizearray.find(i.person.penis) if i.person.penis != 'none' else 4 # handle strapon with default size
 					difference = temppenissize - globals.assholesizearray.find(assholesize)
-					number = 1+(difference*.1)
-					values.sens *= number
-					values.lust *= number
-					if difference > 0 && scenedict.takers.size() <= 1:
-						if assTorn == true:
-							values.sens = values.sens*.75
-							values.lust = values.lust*.75
-							text += "\n[color=red][names2] [anus2] is {^stretched out:sore:aching:raw:hurting} and [his2] pleasure has lessened.[/color]\n "
-					elif difference < 0 && scenedict.takers.size() <= 1:
-						text += "\n[color=red][names2] [anus2] can barely feel [names1] undersized [penis1].[/color] "
+					if assTorn:
+						# If torn, no pleasure boost from a big penetration. It hurts, regardless of size, but some may like it more than others.
+						if person.traits.has('Masochist'):
+							number = 1.2 if person.traits.has('Likes it rough') else 1.1
+							values.sens *= number
+							values.lust *= number
+							if scenedict.takers.size() <= 1:
+								text += "\n[color=green][names2] [anus2] [is2] {^stretched out:sore:aching:raw:hurting}, but [he2] {^seems to get off on it:appears to enjoy it:savours the pain}.[/color] "
+						elif person.traits.has('Likes it rough'):
+							values.sens *= .9
+							values.lust *= .9
+							if scenedict.takers.size() <= 1:
+								text += "\n[color=red][names2] [anus2] [is2] {^stretched out:sore:aching:raw:hurting}, but [he2] {^does [his2] best to take it:gasps and puts up with it:just squeaks and moans a bit}.[/color] "
+						else:
+							values.sens *= .7
+							values.lust *= .7
+							if scenedict.takers.size() <= 1:
+								text += "\n[color=red][names2] [anus2] [is2] {^stretched out:sore:aching:raw:hurting} and [his2] pleasure {^has lessened:[is2] reduced:[is2] diminished}.[/color] "
+					else:
+						# Not torn. Adjust pleasure and mood text based on size.
+						number = 1 + (difference * .1)
+						values.sens *= number
+						values.lust *= number
+						if scenedict.takers.size() <= 1:
+							if difference > 0:
+								if effects.has('resist') || effects.has('forced'):
+									text += "\n[color=green]Despite [his2] best efforts, [name2] can't help but {^enjoy:be excited by:relish} the feeling of [names1] [penis1] stretching [his2] [anus2].[/color] "
+								else:
+									text += "\n[color=green][names2] {^[is2] enjoying:[is2] loving:[is2] relishing:loves} the feeling of [names1] [penis1] stretching [his2] [anus2].[/color] "
+							elif difference < -1:
+								text += "\n[color=red][names2] [anus2] can barely feel [names1] undersized [penis1].[/color] "
+
 					#Stretching
 					if difference >= 5 + rand_range(-5,0) + person.sexexpanded.pliability:
 						if globals.assholesizearray.back() != assholesize:
@@ -1219,15 +1260,15 @@ func rebuildparticipantslist():
 					text += '\n[color=aqua]' + k.name + k.person.dictionary('[/color] feels that being with $his [color=aqua]') + related + '[/color], [color=aqua]' + i.name + '[/color], would be ' + str(k.person.fetish.incest) + '.'
 		#---Wear and Tear
 		if i.vagTorn == true:
-			text += i.person.dictionary("\n[color=red]$name's [color=aqua]pussy[/color] has been stretched beyond it's limit. Penetration Arousal Gains Reduced[/color]")
+			text += i.person.dictionary("\n[color=red]$name's [color=aqua]pussy[/color] has been stretched beyond its limit. Penetration arousal gains reduced.[/color]")
 		if i.assTorn == true:
-			text += i.person.dictionary("\n[color=red]$name's [color=aqua]asshole[/color] has been stretched beyond it's limit. Penetration Arousal Gains Reduced[/color]")
+			text += i.person.dictionary("\n[color=red]$name's [color=aqua]asshole[/color] has been stretched beyond its limit. Penetration arousal gains reduced.[/color]")
 	for i in takers:
 		#---Wear and Tear
 		if i.vagTorn == true:
-			text += i.person.dictionary("\n[color=red]$name's [color=aqua]pussy[/color] has been stretched beyond it's limit. Penetration Arousal Gains Reduced[/color]")
+			text += i.person.dictionary("\n[color=red]$name's [color=aqua]pussy[/color] has been stretched beyond its limit. Penetration arousal gains reduced.[/color]")
 		if i.assTorn == true:
-			text += i.person.dictionary("\n[color=red]$name's [color=aqua]asshole[/color] has been stretched beyond it's limit. Penetration Arousal Gains Reduced[/color]")
+			text += i.person.dictionary("\n[color=red]$name's [color=aqua]asshole[/color] has been stretched beyond its limit. Penetration arousal gains reduced.[/color]")
 #		text += "\n"
 	###---Expansion End---###
 

--- a/scripts/newsexsystem.gd
+++ b/scripts/newsexsystem.gd
@@ -801,12 +801,12 @@ class member:
 					elif difference < 0 && scenedict.givers.size() <= 1:
 						text += "\n[color=red][name1] {^can barely feel:can't feel:can't fill} [names2] [pussy2] with [his1] [penis1].[/color]"
 					#Display
-					if globals.state.perfectinfo == true:
-						display = difference*10
-						if display > 0 && scenedict.givers.size() <= 1:
+					if globals.state.perfectinfo == true && scenedict.givers.size() <= 1:
+						display = difference * 10
+						if display > 0:
 							text += " [color=aqua]Arousal increased by " + str(display) + "%[/color]"
-						elif display < 0 && scenedict.givers.size() <= 1:
-							text += " [color=red]Arousal decreased by " + str(display) + "%[/color]"
+						elif display < 0:
+							text += " [color=red]Arousal decreased by " + str(-display) + "%[/color]"
 				elif scenedict.takers.has(self) && scenedict.givers.has(i):
 					var temppenissize = globals.penissizearray.find(i.person.penis) if i.person.penis != 'none' else 4 # handle strapon with default size
 					difference = temppenissize - globals.vagsizearray.find(vaginasize)
@@ -814,16 +814,19 @@ class member:
 						# If torn, no pleasure boost from a big penetration. It hurts, regardless of size, but some may like it more than others.
 						if person.traits.has('Masochist'):
 							number = 1.2 if person.traits.has('Likes it rough') else 1.1
+							display = 20 if person.traits.has('Likes it rough') else 10
 							values.sens *= number
 							values.lust *= number
 							if scenedict.takers.size() <= 1:
 								text += "\n[color=green][names2] [pussy2] [is2] {^stretched out:sore:aching:raw:hurting}, but [he2] {^seems to get off on it:appears to enjoy it:savours the pain}.[/color] "
 						elif person.traits.has('Likes it rough'):
+							display = -10
 							values.sens *= .9
 							values.lust *= .9
 							if scenedict.takers.size() <= 1:
 								text += "\n[color=red][names2] [pussy2] [is2] {^stretched out:sore:aching:raw:hurting}, but [he2] {^does [his2] best to take it:gasps and puts up with it:just squeaks and moans a bit}.[/color] "
 						else:
+							display = -30
 							values.sens *= .7
 							values.lust *= .7
 							if scenedict.takers.size() <= 1:
@@ -831,6 +834,7 @@ class member:
 					else:
 						# Not torn. Adjust pleasure and mood text based on size.
 						number = 1 + (difference * .1)
+						display = difference * 10
 						values.sens *= number
 						values.lust *= number
 						if scenedict.takers.size() <= 1:
@@ -869,12 +873,11 @@ class member:
 										text += "\n[color=red][name2] {^shouts:screams:cries:sobs:squeals:whimpers} as [his2] [pussy2] {^rips:tears:breaks} even further, causing [him2] excruciating pain.[/color] "
 									person.stress += round(rand_range(difference*2,temppenissize*2))
 					#Display
-					if globals.state.perfectinfo == true:
-						display = difference*10
-						if display > 0 && vagTorn == false:
+					if globals.state.perfectinfo == true && scenedict.takers.size() <= 1:
+						if display > 0:
 							text += " [color=aqua]Arousal increased by " + str(display) + "%[/color]"
 						elif display < 0:
-							text += " [color=red]Arousal decreased by " + str(display) + "%[/color]"
+							text += " [color=red]Arousal decreased by " + str(-display) + "%[/color]"
 
 			#Penis in Asshole Effects
 			elif scenedict.scene.code in ['missionaryanal', 'doggyanal','lotusanal','revlotusanal','spitroastass','insertinturnsass']:
@@ -889,12 +892,12 @@ class member:
 					elif difference < 0 && scenedict.givers.size() <= 1:
 						text += "\n[color=red][name1] {^can barely feel:can't feel:can't fill} [names2] [anus2] with [his1] [penis1].[/color] "
 					#Display
-					if globals.state.perfectinfo == true:
-						display = difference*10
-						if display > 0 && scenedict.givers.size() <= 1:
+					if globals.state.perfectinfo == true && scenedict.givers.size() <= 1:
+						display = difference * 10
+						if display > 0:
 							text += " [color=aqua]Arousal increased by " + str(display) + "%[/color]"
-						elif display < 0 && scenedict.givers.size() <= 1:
-							text += " [color=red]Arousal decreased by " + str(display) + "%[/color]"
+						elif display < 0:
+							text += " [color=red]Arousal decreased by " + str(-display) + "%[/color]"
 				elif scenedict.takers.has(self) && scenedict.givers.has(i):
 					var temppenissize = globals.penissizearray.find(i.person.penis) if i.person.penis != 'none' else 4 # handle strapon with default size
 					difference = temppenissize - globals.assholesizearray.find(assholesize)
@@ -902,16 +905,19 @@ class member:
 						# If torn, no pleasure boost from a big penetration. It hurts, regardless of size, but some may like it more than others.
 						if person.traits.has('Masochist'):
 							number = 1.2 if person.traits.has('Likes it rough') else 1.1
+							display = 20 if person.traits.has('Likes it rough') else 10
 							values.sens *= number
 							values.lust *= number
 							if scenedict.takers.size() <= 1:
 								text += "\n[color=green][names2] [anus2] [is2] {^stretched out:sore:aching:raw:hurting}, but [he2] {^seems to get off on it:appears to enjoy it:savours the pain}.[/color] "
 						elif person.traits.has('Likes it rough'):
+							display = -10
 							values.sens *= .9
 							values.lust *= .9
 							if scenedict.takers.size() <= 1:
 								text += "\n[color=red][names2] [anus2] [is2] {^stretched out:sore:aching:raw:hurting}, but [he2] {^does [his2] best to take it:gasps and puts up with it:just squeaks and moans a bit}.[/color] "
 						else:
+							display = -30
 							values.sens *= .7
 							values.lust *= .7
 							if scenedict.takers.size() <= 1:
@@ -919,6 +925,7 @@ class member:
 					else:
 						# Not torn. Adjust pleasure and mood text based on size.
 						number = 1 + (difference * .1)
+						display = difference * 10
 						values.sens *= number
 						values.lust *= number
 						if scenedict.takers.size() <= 1:
@@ -957,12 +964,11 @@ class member:
 										text += "\n[color=red][name2] {^shouts:screams:cries:sobs:squeals:whimpers} as [his2] [anus2] {^rips:tears:breaks} even further, causing [him2] excruciating pain.[/color] "
 									person.stress += round(rand_range(difference*2,temppenissize*2))
 					#Display
-					if globals.state.perfectinfo == true:
-						display = difference*10
-						if display > 0 && scenedict.takers.size() <= 1:
+					if globals.state.perfectinfo == true && scenedict.takers.size() <= 1:
+						if display > 0:
 							text += " [color=aqua]Arousal increased by " + str(display) + "%[/color]"
-						elif display < 0 && scenedict.takers.size() <= 1:
-							text += " [color=red]Arousal decreased by " + str(display) + "%[/color]"
+						elif display < 0:
+							text += " [color=red]Arousal decreased by " + str(-display) + "%[/color]"
 				
 			#Milking during Sex
 			elif scenedict.scene.code in ['milker','sucknipples']:

--- a/scripts/newsexsystem.gd
+++ b/scripts/newsexsystem.gd
@@ -859,7 +859,8 @@ class member:
 								if vagTorn == false:
 									vagTorn = true
 									person.dailyevents.append('vagTorn')
-									globals.addrelations(person, i.person, -round(rand_range(difference*5,difference*10)))
+									if !person.traits.has('Masochist') && !person.traits.has('Likes it rough'):
+										globals.addrelations(person, i.person, -round(rand_range(difference*5,difference*10)))
 									if scenedict.givers.size() <= 1:
 										text += "\n[color=red][name2] {^shouts:screams:cries:sobs:squeals:whimpers} as [his2] [pussy2] suddenly {^rips:tears:breaks:starts bleeding}, sending waves of pain through [his2] body.[/color] "
 									person.stress += round(rand_range(difference,temppenissize))
@@ -946,7 +947,8 @@ class member:
 								if assTorn == false:
 									assTorn = true
 									person.dailyevents.append('assTorn')
-									globals.addrelations(person, i.person, -round(rand_range(difference*5,difference*10)))
+									if !person.traits.has('Masochist') && !person.traits.has('Likes it rough'):
+										globals.addrelations(person, i.person, -round(rand_range(difference*5,difference*10)))
 									if scenedict.takers.size() <= 1:
 										text += "\n[color=red][name2] {^shouts:screams:cries:sobs:squeals:whimpers} as [his2] [anus2] suddenly {^rips:tears:breaks:starts bleeding}, sending waves of pain through [his2] body.[/color]"
 									person.stress += round(rand_range(difference,temppenissize))

--- a/scripts/newsexsystem.gd
+++ b/scripts/newsexsystem.gd
@@ -769,6 +769,7 @@ class member:
 			var difference = 0
 			var display = 0
 			var clamper = 0
+			var roughSex = effects.has('resist') || effects.has('forced')
 			#Mouth Effects
 			if scenedict.scene.code in ['blowjob','spitroast','spitroastass','deepthroat']:
 				number = 1+((globals.lipssizearray.find(i.person.lips)-3)*.1)
@@ -834,7 +835,7 @@ class member:
 						values.lust *= number
 						if scenedict.takers.size() <= 1:
 							if difference > 0:
-								if effects.has('resist') || effects.has('forced'):
+								if roughSex:
 									text += "\n[color=green]Despite [his2] best efforts, [name2] can't help but {^enjoy:be excited by:relish} the feeling of [names1] [penis1] stretching [his2] [pussy2].[/color] "
 								else:
 									text += "\n[color=green][names2] {^[is2] enjoying:[is2] loving:[is2] relishing:loves} the feeling of [names1] [penis1] stretching [his2] [pussy2].[/color] "
@@ -850,7 +851,11 @@ class member:
 							if scenedict.takers.size() <= 1:
 								text += "\n[color=green][name2] {^moans:gasps:spasms:twitches:bites [his2] lip} as [his2] [pussy2] [is2] {^stretched:gaped:spread apart:forced to stretch} by [names1] [penis1].[/color] "
 							var stretch = globals.vagsizearray.find(vaginasize) - globals.vagsizearray.find(person.vagina)
-							if globals.expansionsettings.disablevaginatearing == false && person.sexexpanded.pliability - stretch + rand_range(0,2) < 0:
+							# Increased chance to tear if taker is unwilling.
+							number = rand_range(0, 2)
+							if roughSex:
+								number -= 1
+							if globals.expansionsettings.disablevaginatearing == false && person.sexexpanded.pliability - stretch + number < 0:
 								if vagTorn == false:
 									vagTorn = true
 									person.dailyevents.append('vagTorn')
@@ -917,7 +922,7 @@ class member:
 						values.lust *= number
 						if scenedict.takers.size() <= 1:
 							if difference > 0:
-								if effects.has('resist') || effects.has('forced'):
+								if roughSex:
 									text += "\n[color=green]Despite [his2] best efforts, [name2] can't help but {^enjoy:be excited by:relish} the feeling of [names1] [penis1] stretching [his2] [anus2].[/color] "
 								else:
 									text += "\n[color=green][names2] {^[is2] enjoying:[is2] loving:[is2] relishing:loves} the feeling of [names1] [penis1] stretching [his2] [anus2].[/color] "
@@ -933,7 +938,11 @@ class member:
 							if scenedict.takers.size() <= 1:
 								text += "\n[color=green][name2] {^starts:begins} {^moaning:gasping:spasming} as [his2] [anus2] [is2] {^stretched:gaped:spread apart:forced to stretch} by [names1] [penis1].[/color] "
 							var stretch = globals.assholesizearray.find(assholesize) - globals.assholesizearray.find(assholesize)
-							if globals.expansionsettings.disableanaltearing == false && person.sexexpanded.pliability - stretch + rand_range(0,2) < 0:
+							# Increased chance to tear if taker is unwilling.
+							number = rand_range(0, 2)
+							if roughSex:
+								number -= 1
+							if globals.expansionsettings.disableanaltearing == false && person.sexexpanded.pliability - stretch + number < 0:
 								if assTorn == false:
 									assTorn = true
 									person.dailyevents.append('assTorn')


### PR DESCRIPTION
Updated the wear-and-tear system:
* Adjust pleasure modifier when torn, depending on traits.
* Adjust mood text when torn, depending on traits.
* If torn, should not show text that says the girl loves being stretched.
* If unwilling, text should say pleasure is reluctant.
* Slightly increase the chance to tear during forced sex.
* No relationship penalty for tearing if masochist or likes it rough.
* Display arousal changes correctly if perfectinfo flag is set.
* Lose hitpoints when torn, but the character can't die.

In this case, it might be easier to view changes in individual commits, rather than all together. I'm open to any feedback, including "no, we won't do this at all".
