### PR TITLE
Hide the list of available talk subjects for slaves you don't own

### DIFF
--- a/scripts/characters/description.gd
+++ b/scripts/characters/description.gd
@@ -1,4 +1,5 @@
 
+# Valid values for mode are "default" and "compact".
 func getslavedescription(tempperson, mode = 'default'):
 	showmode = mode
 	person = tempperson
@@ -55,7 +56,7 @@ func getslavedescription(tempperson, mode = 'default'):
 ###---Added by Expansion---### Once Per Day Notifications
 func onceperdayConvos():
 	var text = '\n'
-	if globals.expansionsettings.show_onceperday_notification == true && person != globals.player:
+	if globals.expansionsettings.show_onceperday_notification && person != globals.player && showmode == 'default':
 		text += "\n[center][color=#d1b970]---Once Per Day Talk Subjects Still Available Today---[/color][/center]"
 		#Consent
 		if !person.dailytalk.has('consentparty') && person.consentexp.party == false:


### PR DESCRIPTION
Hide the "Once per day talk subjects still available today" section in person descriptions, unless you own the slave.

If you're at the market, or have just captured somebody in combat, you don't particularly care about this. It's just a tiny fix - I didn't even need to add another parameter to the function. I don't think the compact mode is used anywhere where you would want to see the talk subjects list, but please correct me if I'm wrong.