### PR TITLE
Bugfix for cum not deposited in mouth during facefuck action

### DIFF
--- a/scripts/newsexsystem.gd
+++ b/scripts/newsexsystem.gd
@@ -381,6 +381,10 @@ class member:
 								for i in scene.takers:
 									i.person.cum.ass += person.pregexp.cumprod
 									i.person.checkFetish('creampieass')
+							elif scene.scene.takerpart == 'mouth':
+								for i in scene.takers:
+									i.person.cum.mouth += person.pregexp.cumprod
+									i.person.checkFetish('creampiemouth')
 							###---End Expansion---###
 						if scene.scene.code in ['doublepen','triplepen']: # Capitulize
 							for i in scene.takers:


### PR DESCRIPTION
Ensure that, after an orgasm, the giver's cum is deposited in takers' mouths during facefuck, same as with a blowjob. It might apply to actions other than facefuck, but it should still be correct to add the cum.

The taker's request for cum in her mouth was previously not satisfied by a facefuck. This fix should remedy that.

It looks like the mouth clause was just omitted, so I added it. Please verify that this does not have unintended consequences.