### PR TITLE
Fix script error when using deadly blow

### DIFF
--- a/scripts/abilities.gd
+++ b/scripts/abilities.gd
@@ -121,6 +121,7 @@ var abilitydict = {
 		usetext = '$name goes for a deadly blow. ',
 		target = 'one',
 		targetgroup = 'enemy',
+		effect = null,
 		can_miss = true,
 		learncost = 35,
 		power = 2,


### PR DESCRIPTION
Deadly blow has no effect member and causes a script error at scripts/combat.gd 1055. (And freezes us the game)