### PR TITLE
Image loading performance tweaks

### DIFF
--- a/globals.gd
+++ b/globals.gd
@@ -183,6 +183,12 @@ func slaves_set(person):
 	if globals.get_tree().get_current_scene().has_node("infotext"):
 		globals.get_tree().get_current_scene().infotext("New Character acquired: " + person.name_long(),'green')
 
+<RemoveFrom 6 7>
+func canloadimage(path):
+	# if Image.new().load(path) != OK:
+	# 	return false
+
+
 class resource:
 	var day = 1 setget day_set
 	var gold = 0 setget gold_set

--- a/scripts/Mansion.gd
+++ b/scripts/Mansion.gd
@@ -4774,8 +4774,14 @@ func updateSlaveListNode(node, person, visible):
 	node.find_node('healthvalue').set_text( str(round(person.health)))
 	node.find_node('obedience').set_normal_texture( person.obed_icon())
 	node.find_node('stress').set_normal_texture( person.stress_icon())
-	if person.imageportait != null:
-		node.find_node('portait').set_texture( globals.loadimage(person.imageportait))
+	# Don't reload the image if it didn't change, since it can be slow to reload images for a large slave list
+	var portrait_node = node.find_node('portait')
+	if !portrait_node.has_meta('imageportait') || (portrait_node.get_meta('imageportait') != person.imageportait):
+		if person.imageportait != null:
+			portrait_node.set_texture(globals.loadimage(person.imageportait))
+		else:
+			portrait_node.set_texture(null)
+		portrait_node.set_meta('imageportait', person.imageportait)
 
 func dialogue(showcloseButton, destination, dialogtext, dialogbuttons = null, sprites = null, background = null): #for arrays: 0 - boolean to show close button or not. 1 - node to return connection back. 2 - text to show 3+ - arrays of buttons and functions in those
 	var text = get_node("dialogue/dialoguetext")


### PR DESCRIPTION
Edit Mansion slave list updating to not reload images that didn't change.

Don't actually load the image in canloadimage(), since that can be slow when called a lot. Will change behavior in a couple places if the file exists but can't be loaded, showing a blank panel instead it being hidden.

Could potentially also change loadimage() to return a special "Couldn't load image" texture to notify the user a file couldn't be loaded - currently it returns null which will show up as blank.